### PR TITLE
Unify manners in authN service

### DIFF
--- a/back-end/service/authN-service.js
+++ b/back-end/service/authN-service.js
@@ -72,22 +72,22 @@ const service = {
   },
   getUserFromToken: (req, res, next) => {
     try {
-      let decoded = jwt.verify(req.cookies['token'], secret, { algorithms: ['HS256'] });
       if (req.cookies['token']) {
-        console.log(decoded);
+        let decoded = jwt.verify(req.cookies['token'], secret, { algorithms: ['HS256'] });
         res.json({
           success: true,
           user: decoded
         });
       } else {
-        res.json({
-          success: true,
+        res.status(401).json({
+          success: false,
           user: null
         });
       }
     } catch (err) {
-      res.json({
-        success: true,
+      console.log(err);
+      res.status(500).json({
+        success: false,
         user: null
       });
     }


### PR DESCRIPTION
* print error not to logger but to `console.log` (not sure why, I just unify existing behaviour)
* make sure we have token before we use it
* stop emitting decoded data to `console.log` for security